### PR TITLE
Ignore type checking imports if option set in project config

### DIFF
--- a/tach/check.py
+++ b/tach/check.py
@@ -180,7 +180,11 @@ def check(
         nearest_package = package_trie.find_nearest(mod_path)
         if nearest_package is None:
             continue
-        import_mod_paths = get_project_imports(root, file_path)
+        import_mod_paths = get_project_imports(
+            root,
+            file_path,
+            ignore_type_checking_imports=project_config.ignore_type_checking_imports,
+        )
         # This should only give us imports from within our project
         # (excluding stdlib, builtins, and 3rd party packages)
         for import_mod_path in import_mod_paths:

--- a/tach/core/config.py
+++ b/tach/core/config.py
@@ -50,7 +50,8 @@ class ProjectConfig(Config):
 
     constraints: List[TagDependencyRules] = Field(default_factory=list)
     exclude: Optional[List[str]] = Field(default_factory=lambda: ["tests", "docs"])
-    exclude_hidden_paths: Optional[bool] = True
+    exclude_hidden_paths: bool = True
+    ignore_type_checking_imports: bool = False
 
     def dependencies_for_tag(self, tag: str) -> list[str]:
         return next(


### PR DESCRIPTION
Issue: #56 

Adds an option which can be set in `tach.yml` called `ignore_type_checking_imports`.

When `true`, imports that are nested at any level beneath `if TYPE_CHECKING:` will be ignored when validating your dependencies.

ex:
```
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from core import CoreModule

```
When this new option is `true`, the import above from `core` will not be checked.
