### PR TITLE
Pre-commit root arg

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,6 @@
   name: tach
   description: Validate package dependencies
   entry: tach check
+  args: ["--root"]
   language: python
   pass_filenames: false

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,7 +80,7 @@ If you use the [pre-commit framework](https://github.com/pre-commit/pre-commit),
 ```yaml
 repos:
 -   repo: https://github.com/Never-Over/tach
-    rev: v0.1.2
+    rev: v0.1.9  # change this to the latest tag!
     hooks:
     -   id: tach
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tach"
-version = "0.1.8"
+version = "0.1.9"
 authors = [
   { name="Caelean Barnes", email="caeleanb@gmail.com" },
   { name="Evan Doyle", email="evanmdoyle@gmail.com" },

--- a/tach/hooks/pre-commit
+++ b/tach/hooks/pre-commit
@@ -1,4 +1,23 @@
 #!/bin/sh
 # Pre-commit script that validates dependencies locally
+set -e
 
-exec tach check
+# Default values
+root_dir="."
+
+
+# Parse command-line arguments
+for arg in "$@"; do
+    case $arg in
+        --root=*)
+            root_dir="${arg#*=}"
+            shift
+            ;;
+        *)
+            echo "Unknown parameter passed to 'tach' pre-commit hook: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+cd "$root_dir" && tach check

--- a/tach/hooks/pre-commit
+++ b/tach/hooks/pre-commit
@@ -2,9 +2,7 @@
 # Pre-commit script that validates dependencies locally
 set -e
 
-# Default values
 root_dir="."
-
 
 # Parse command-line arguments
 for arg in "$@"; do


### PR DESCRIPTION
This allows users on the 'pre-commit' framework to adjust the root directory from which `tach check` will run during the pre-commit hook.

Example:
```
repos:
-   repo: https://github.com/Never-Over/tach
    rev: v0.1.8
    hooks:
    -   id: tach
    args:
    -   --root=backend
```